### PR TITLE
Making an option to not use large icon in PugNotification

### DIFF
--- a/pugnotification/src/main/java/br/com/goncalves/pugnotification/notification/Load.java
+++ b/pugnotification/src/main/java/br/com/goncalves/pugnotification/notification/Load.java
@@ -42,8 +42,13 @@ public class Load {
         this.builder.setContentTitle("");
         this.builder.setContentText("");
         this.builder.setSmallIcon(R.drawable.pugnotification_ic_launcher);
-        this.builder.setLargeIcon(BitmapFactory.decodeResource(mNotification.mContext.getResources(),
-                R.drawable.pugnotification_ic_launcher));
+
+        // FIX: Not setting a default LargeIcon, to make an option to use or not use a large icon in notification. Otherwise I'll get an Android icon plus smallIcon in notification.
+        // I tested it in Sample App and it worked. Just comment .largeIcon() line in PugNotification builder to test.
+
+        //this.builder.setLargeIcon(BitmapFactory.decodeResource(mNotification.mContext.getResources(),
+        //        R.drawable.pugnotification_ic_launcher));
+
         this.builder.setContentIntent(PendingIntent.getBroadcast(mNotification.mContext, 0, new Intent(), PendingIntent.FLAG_UPDATE_CURRENT));
     }
 


### PR DESCRIPTION
Not setting a default LargeIcon, to make an option to use or not use a large icon in notification. Otherwise I'll get an Android icon (R.drawable.pugnotification_ic_launcher) plus smallIcon in notification.

I tested it in Sample App and it works. Just comment .largeIcon() line in PugNotification builder to test.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/halysongoncalves/pugnotification/20)

<!-- Reviewable:end -->
