### PR TITLE
Fix messageSpanned length check

### DIFF
--- a/library/src/main/java/br/com/goncalves/pugnotification/notification/Load.java
+++ b/library/src/main/java/br/com/goncalves/pugnotification/notification/Load.java
@@ -95,7 +95,7 @@ public class Load {
     }
 
     public Load message(@NonNull Spanned messageSpanned) {
-        if (message.length() == 0) {
+        if (messageSpanned.length() == 0) {
             throw new IllegalArgumentException("Message Must Not Be Empty!");
         }
 


### PR DESCRIPTION
When you pass a messageSpanned, the method checks message member and not the messageSpanned parameter which is not correct and causes null pointer exception

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/halysongoncalves/pugnotification/39)

<!-- Reviewable:end -->
